### PR TITLE
make selected options stick, add a new theme, some small edits

### DIFF
--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -68,6 +68,14 @@ export default Vue.extend({
     props: {
         listOfTripNames: { required: true, type: Array }
     },
+    data: function(){
+        // default option values 
+        // TODO: make a type for these
+        return {
+            mapType: "watercolor",
+            theme: "pastel",
+        }
+    },
     methods: {
         addNewTrip: async function(): Promise<void> {
             const modalHandler = new Modal();
@@ -136,19 +144,34 @@ export default Vue.extend({
                 document.documentElement.style.setProperty('--column-1-bg-color', 'var(--light-gray)');
                 document.documentElement.style.setProperty('--column-2-bg-color', 'var(--grayish-red)');
                 document.documentElement.style.setProperty('--destination-list-bg-color', 'var(--light-grayish-orange)');
+            }else if(themeName === "beach"){
+                // https://colorhunt.co/palette/9ac5f499dbf5a7eceeffeebb
+                document.documentElement.style.setProperty('--menu-header-bg-color', 'var(--soft-blue)');
+                document.documentElement.style.setProperty('--destination-bg-color', 'var(--sky-blue)');
+                document.documentElement.style.setProperty('--column-1-bg-color', 'var(--sky-blue)');
+                document.documentElement.style.setProperty('--column-2-bg-color', 'var(--pale-turquoise)');
+                document.documentElement.style.setProperty('--destination-list-bg-color', 'var(--oasis)');
             }
         },
         
         openOptions: async function(): Promise<void> {
             const modal = new Modal();
             
-            // TODO: don't use any
-            const currOptions: OverpassAPIOptions = (this.$root as any).getCurrentOverpassAPIOptions();
-            const data: UserSelectedOptionsInModal | Record<string, never> = await modal.createOptionsModal(currOptions);
+            // TODO: don't use any + create type for otherOptions
+            const overpassOptions: OverpassAPIOptions = (this.$root as any).getCurrentOverpassAPIOptions();
+            const otherOptions: Record<string, string> = {mapType: this.mapType, theme: this.theme};
+            
+            const data: UserSelectedOptionsInModal | Record<string, never> = await modal.createOptionsModal(overpassOptions, otherOptions);
             
             // execute some changes based on selected options
-            if(data["mapType"]) this.changeMapStyle(data["mapType"]);
-            if(data["theme"]) this.changeStyleTheme(data["theme"]);
+            if(data["mapType"]){
+                this.changeMapStyle(data["mapType"]);
+                this.mapType = data["mapType"];
+            }
+            if(data["theme"]){
+                this.changeStyleTheme(data["theme"]);
+                this.theme = data["theme"];
+            }
             
             this.$emit('update-options', data);
         }

--- a/src/utils/modal.ts
+++ b/src/utils/modal.ts
@@ -160,14 +160,15 @@ export class Modal {
         });
     }
 
-    createOptionsModal(currOptions: OverpassAPIOptions): Promise<UserSelectedOptionsInModal | Record<string, never>> {
+    // TODO: just one options object?
+    createOptionsModal(overpassOptions: OverpassAPIOptions, otherOptions: Record<string, string>): Promise<UserSelectedOptionsInModal | Record<string, never>> {
         const modal = document.createElement('div');
         modal.id = "modal";
         Object.assign(modal.style, this.modalStyle);
         
         // get current option values so we can set them
-        const overpassApiEnabled = currOptions.useOverpassAPI;
-        const selectedOverpassApiEntity = currOptions.selectedOverpassApiEntity;
+        const overpassApiEnabled = overpassOptions.useOverpassAPI;
+        const selectedOverpassApiEntity = overpassOptions.selectedOverpassApiEntity;
 
         const displayText = document.createElement('h1');
         displayText.textContent = "options";
@@ -219,7 +220,7 @@ export class Modal {
         overpassApiSelect.style.margin = '10px';
         overpassApiSelect.disabled = !overpassApiEnabled;
 
-        const overpassEntities: string[] = currOptions.overpassEntities;
+        const overpassEntities: string[] = overpassOptions.overpassEntities;
         overpassEntities.forEach(type => {
             const opt = document.createElement('option');
             opt.value = type;
@@ -259,6 +260,11 @@ export class Modal {
             const opt = document.createElement('option');
             opt.value = type;
             opt.textContent = type;
+            
+            if(otherOptions.mapType && otherOptions.mapType === type){
+                opt.setAttribute('selected', 'true');
+            }
+            
             mapTypeSelect.appendChild(opt);
         });
         mapTypeSelect.style.marginBottom = "6px";
@@ -276,11 +282,16 @@ export class Modal {
         // select theme
         const themeSelect = document.createElement('select');
         themeSelect.id = "themeSelect";
-        const themes = ["pastel", "gray"];
+        const themes = ["pastel", "gray", "beach"];
         themes.forEach(themeName => {
             const themeOption = document.createElement('option');
             themeOption.textContent = themeName;
             themeOption.value = themeName;
+            
+            if(otherOptions.theme && otherOptions.theme === themeName){
+                themeOption.setAttribute('selected', 'true');
+            }
+            
             themeSelect.appendChild(themeOption);
         });
         themeSelect.style.marginTop = "6px";

--- a/src/variables.css
+++ b/src/variables.css
@@ -20,6 +20,10 @@
     --dark-red: #8b0000;
     --purple: #6a5acd;
     --dark-purple: #5541cc;
+    --soft-blue: #9ac5f4;
+    --sky-blue: #99dbf5;
+    --pale-turquoise: #a7ecee;
+    --oasis: #ffeebb;
     --transparent-white: rgba(255, 255, 255, 0.5);
     
     /* theme-related variables and their default values */


### PR DESCRIPTION
- options that are modified will "stick" so that they will be shown as the currently-selected option when the options menu is opened again
- refactored a little (made a new function to reduce redundant code)
- added a new theme ("beach")
![image](https://github.com/syncopika/trip-planner/assets/8601582/31f10f51-51e0-4f93-8622-92c41ec7df46)
