### PR TITLE
make ui a bit more mobile-friendly

### DIFF
--- a/src/components/TripRoute.vue
+++ b/src/components/TripRoute.vue
@@ -282,8 +282,16 @@ label {
 
 #main {
     display: flex;
-    flex-direction: row; /* TODO: flex-direction: column; might be helpful for mobile view? */
+    flex-direction: row;
     background-color: var(--black);
+}
+
+@media screen and (max-width: 800px) {
+    #main {
+        display: flex;
+        flex-direction: column;
+        background-color: var(--black);
+    }
 }
 
 #mapContainer {


### PR DESCRIPTION
modified css so it should now look like the below on smaller screens:
![image](https://github.com/syncopika/trip-planner/assets/8601582/085d0239-7e53-445c-bfeb-3edd47335f31)
